### PR TITLE
Error

### DIFF
--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -847,7 +847,19 @@ def collaborate(snap_name, key):
 
     assertion = _sign_assertion(snap_name, assertion, key, 'developers')
 
-    store.push_assertion(snap_id, assertion, 'developers')
+    try:
+        store.push_assertion(snap_id, assertion, 'developers')
+    except storeapi.errors.StoreValidationError as e:
+        if e.error_list[0]['code'] == 'revoked-uploads':
+            print("This will revoke the following uploads: {}".format(
+                e.error_list[0]['extra']))
+            if input('Are you sure you want to continue (y/N): ') == 'y':
+                store.push_assertion(
+                    snap_id, assertion, 'developers', force=True)
+            else:
+                raise
+        else:
+            raise
 
 
 def _get_developers(snap_id, publisher_id):

--- a/snapcraft/_store.py
+++ b/snapcraft/_store.py
@@ -24,6 +24,7 @@ import operator
 import os
 import re
 import subprocess
+import sys
 import tempfile
 
 from subprocess import Popen
@@ -853,11 +854,12 @@ def collaborate(snap_name, key):
         if e.error_list[0]['code'] == 'revoked-uploads':
             print("This will revoke the following uploads: {}".format(
                 e.error_list[0]['extra']))
-            if input('Are you sure you want to continue (y/N): ') == 'y':
+            if input("Are you sure you want to continue (y/N): ") == "y":
                 store.push_assertion(
                     snap_id, assertion, 'developers', force=True)
             else:
-                raise
+                print("The collaborators for this snap haven't been altered")
+                sys.exit(1)
         else:
             raise
 

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -320,8 +320,8 @@ class StoreClient():
                 file_sum.update(file_chunk)
         return expected_sha512 == file_sum.hexdigest()
 
-    def push_assertion(self, snap_id, assertion, endpoint):
-        return self.sca.push_assertion(snap_id, assertion, endpoint)
+    def push_assertion(self, snap_id, assertion, endpoint, force=False):
+        return self.sca.push_assertion(snap_id, assertion, endpoint, force)
 
     def get_assertion(self, snap_id, endpoint):
         return self.sca.get_assertion(snap_id, endpoint)
@@ -595,7 +595,7 @@ class SCAClient(Client):
 
         return response_json
 
-    def push_assertion(self, snap_id, assertion, endpoint):
+    def push_assertion(self, snap_id, assertion, endpoint, force):
         if endpoint == 'validations':
             data = {
                 'assertion': assertion.decode('utf-8'),
@@ -605,13 +605,21 @@ class SCAClient(Client):
                 'snap_developer': assertion.decode('utf-8'),
             }
         auth = _macaroon_auth(self.conf)
+
+        url = 'snaps/{}/{}'.format(snap_id, endpoint)
+
+        # For `snap-developer`, revoking developers will require their uploads
+        # to be invalidated.
+        if force:
+            url = url + '?ignore_revoked_uploads'
+
         response = self.put(
-            'snaps/{}/{}'.format(snap_id, endpoint), data=json.dumps(data),
+            url, data=json.dumps(data),
             headers={'Authorization': auth,
                      'Content-Type': 'application/json',
                      'Accept': 'application/json'})
+
         if not response.ok:
-            # First check if an upload-revokation error for snap developer.
             raise errors.StoreValidationError(snap_id, response)
         try:
             response_json = response.json()

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -611,6 +611,7 @@ class SCAClient(Client):
                      'Content-Type': 'application/json',
                      'Accept': 'application/json'})
         if not response.ok:
+            # First check if an upload-revokation error for snap developer.
             raise errors.StoreValidationError(snap_id, response)
         try:
             response_json = response.json()

--- a/snapcraft/storeapi/errors.py
+++ b/snapcraft/storeapi/errors.py
@@ -331,7 +331,9 @@ class StoreValidationError(StoreError):
     def __init__(self, snap_id, response, message=None):
         try:
             response_json = response.json()
-            response_json['text'] = response.json()['error_list'][0]['message']
+            error = response.json()['error_list'][0]
+            response_json['text'] = error.get('message')
+            response_json['extra'] = error.get('extra')
         except (AttributeError, JSONDecodeError):
             response_json = {'text': message or response}
 

--- a/snapcraft/tests/commands/test_collaborate.py
+++ b/snapcraft/tests/commands/test_collaborate.py
@@ -1,4 +1,4 @@
-# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:5 -*-
 #
 # Copyright (C) 2017 Canonical Ltd
 #
@@ -39,6 +39,7 @@ class CollaborateTestCase(tests.TestCase):
         self.client = storeapi.StoreClient()
         patcher = mock.patch('snapcraft._store.Popen')
         self.popen_mock = patcher.start()
+
         process_mock = mock.Mock()
         process_mock.returncode = 0
         process_mock.communicate.return_value = [b'foo', b'']
@@ -90,3 +91,17 @@ class CollaborateTestCase(tests.TestCase):
         self.assertEqual(
                 'Received error 400: "The given `snap-id` does not match '
                 'the assertion\'s."', str(err))
+
+    def test_collaborate_yes_revoke_uploads_request(self):
+        patcher = mock.patch('builtins.input')
+        mock_input = patcher.start()
+        mock_input.return_value = 'y'
+        self.client.login('dummy', 'test correct password')
+        err = self.assertRaises(
+            storeapi.errors.StoreValidationError,
+            collaborate,
+            'revoked', 'keyname')
+
+        self.assertEqual(
+            'Received error 409: "The assertion\'s `developers` would revoke '
+            'existing uploads."', str(err))

--- a/snapcraft/tests/fake_servers.py
+++ b/snapcraft/tests/fake_servers.py
@@ -841,6 +841,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._DEV_API_PATH, 'snaps/no-dev/developers')
         bad_developers_path = urllib.parse.urljoin(
             self._DEV_API_PATH, 'snaps/badrequest/developers')
+        revoked_developers_path = urllib.parse.urljoin(
+            self._DEV_API_PATH, 'snaps/revoked/developers')
 
         if parsed_path.path.startswith(details_good):
             self._handle_scan_complete_request('ready_to_release', True)
@@ -864,6 +866,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._handle_developers_request('no-dev')
         elif parsed_path.path.startswith(bad_developers_path):
             self._handle_developers_request('badrequest')
+        elif parsed_path.path.startswith(revoked_developers_path):
+            self._handle_developers_request('revoked')
         elif parsed_path.path.startswith(snap_path):
             if parsed_path.path.endswith('/history'):
                 self._handle_snap_revisions()
@@ -948,6 +952,10 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             status = 200
             response = {'snap_developer': {}}
             response = json.dumps(response).encode()
+        elif code == 'revoked':
+            status = 200
+            response = {'snap_developer': {}}
+            response = json.dumps(response).encode()
         self.send_response(status)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
@@ -1002,6 +1010,9 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             'badrequest': {'snap-id': 'badrequest', 'status': 'Approved',
                            'private': False, 'price': None,
                            'since': '2016-12-12T01:01:01Z'},
+            'revoked': {'snap-id': 'revoked', 'status': 'Approved',
+                        'private': False, 'price': None,
+                        'since': '2016-12-12T01:01:01Z'},
             }
         snaps.update({
             name: {'snap-id': 'fake-snap-id', 'status': 'Approved',
@@ -1133,6 +1144,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._DEV_API_PATH, 'snaps/no-dev/developers')
         bad_developers_path = urllib.parse.urljoin(
             self._DEV_API_PATH, 'snaps/badrequest/developers')
+        revoked_developers_path = urllib.parse.urljoin(
+            self._DEV_API_PATH, 'snaps/revoked/developers')
 
         if parsed_path.path.startswith(good_validations_path):
             self._handle_push_validation_request('good')
@@ -1146,6 +1159,8 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
             self._handle_push_developers_request('no-dev')
         elif parsed_path.path.startswith(bad_developers_path):
             self._handle_push_developers_request('badrequest')
+        elif parsed_path.path.startswith(revoked_developers_path):
+            self._handle_push_developers_request('revoked')
         else:
             logger.error(
                 'Not implemented path in fake Store API server: {}'.format(
@@ -1185,6 +1200,14 @@ class FakeStoreAPIRequestHandler(BaseHTTPRequestHandler):
                 {'message': "The given `snap-id` does not match the "
                             "assertion's.",
                  'code': 'invalid-request'}]}
+            response = json.dumps(response).encode()
+        elif code == 'revoked':
+            status = 409
+            response = {'error_list': [
+                {'message': "The assertion's `developers` would revoke "
+                            "existing uploads.",
+                 'code': 'revoked-uploads',
+                 'extra': ['this']}]}
             response = json.dumps(response).encode()
         self.send_response(status)
         self.send_header('Content-Type', 'application/json')


### PR DESCRIPTION
Revoking developers via snap-developer means that the uploads they performed in the past will need to be invalidated too. 
This PR is to warn the user about the existence of such uploads and to enable a force option.